### PR TITLE
Don't use VkPhysicalDeviceShaderObjectFeaturesEXT without VK_EXT_shad…

### DIFF
--- a/src/dgcgears.c
+++ b/src/dgcgears.c
@@ -224,7 +224,7 @@ init_vk(const char *extension)
 
    VkPhysicalDeviceVulkan13Features feats13 = {
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES,
-      &shobj,
+      use_shader_object ? &shobj : NULL,
       .dynamicRendering = VK_TRUE
    };
 


### PR DESCRIPTION
…er_object

Avoids a validation error:
```
VUID-VkDeviceCreateInfo-pNext-pNext(ERROR / SPEC): msgNum: -1876993556 - Validation Error: [ VUID-VkDeviceCreateInfo-pNext-pNext ] Object 0: handle = 0x29da6b70, type = VK_OBJECT_TYPE_INSTANCE; | MessageID = 0x901f59ec | vkCreateDevice(): pCreateInfo->pNext<VkPhysicalDeviceShaderObjectFeaturesEXT> includes a pointer to a VkPhysicalDeviceShaderObjectFeaturesEXT, but when creating VkDevice, the parent extension (VK_EXT_shader_object) was not included in ppEnabledExtensionNames. The Vulkan spec states: Each pNext member of any structure (including this one) in the pNext chain must be either NULL or a pointer to a valid struct for extending VkDeviceCreateInfo (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkDeviceCreateInfo-pNext-pNext)
```